### PR TITLE
Support chunked read and write

### DIFF
--- a/tabelio/convert_scripts.py
+++ b/tabelio/convert_scripts.py
@@ -9,5 +9,6 @@ def csv2hdf():
 
     args = parser.parse_args()
     convert_table_file(
-        filename=args.filename, from_format='csv', to_format='hdf'
+        filename=args.filename, from_format='csv', to_format='hdf',
+        progress=True
     )

--- a/tabelio/utils.py
+++ b/tabelio/utils.py
@@ -1,0 +1,56 @@
+def _ceil_div(dividend, divisor):
+    return dividend // divisor + (1 if dividend % divisor else 0)
+
+
+class Sequence(object):
+    """Base object for an indexable iterable.
+
+    Every `Sequence` must implement the `__getitem__` and
+    the `__len__` methods.
+    The method `__getitem__` should return a complete batch.
+
+    https://github.com/keras-team/keras/blob/master/keras/utils/data_utils.py
+    """
+
+    def __getitem__(self, index):
+        """Get batch at position `index`.
+
+        # Arguments
+            index: position of the chunk in the Sequence.
+        # Returns
+            A batch
+        """
+        raise NotImplementedError
+
+    def __len__(self):
+        """Get number of chunks in the Sequence.
+
+        # Returns
+            The number of chunks in the Sequence.
+        """
+        raise NotImplementedError
+
+    def __iter__(self):
+        """Create a generator that iterate over the Sequence."""
+        for item in (self[i] for i in range(len(self))):
+            yield item
+
+
+class PandasBatchGenerator(Sequence):
+    """Yield pd.DataFrame in batches as sub-frames."""
+
+    def __init__(self, df, batch_size=None):
+        self.df = df
+        self.batch_size = batch_size
+
+    def __len__(self):
+        return _ceil_div(len(self.df), self.batch_size)
+
+    def __getitem__(self, batch_idx):
+        batch_idx = batch_idx % len(self)
+        columns = self.df.columns
+        batch_size = self.batch_size or len(self.df)
+        batch_df = self.df[columns].iloc[batch_idx * batch_size:
+                                         batch_idx * batch_size + batch_size]
+
+        return batch_df

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,49 @@
+import pytest
+
+from tabelio.mock import mock_table_data
+from tabelio.utils import _ceil_div, PandasBatchGenerator
+
+
+@pytest.mark.parametrize(
+    'dividend, divisor, result', [
+        (0, 1, 0),
+        (0, 2, 0),
+        (1, 1, 1),
+        (1, 2, 1),
+        (2, 2, 1),
+        (2, 1, 2),
+    ]
+)
+def test_ceil_div(dividend, divisor, result):
+    assert _ceil_div(dividend, divisor) == result
+
+
+class TestPandasBatchGenerator:
+    @pytest.mark.parametrize(
+        'n_rows, batch_size, expected_nb_batches', [
+            (0, 2, 0),
+            (1, 2, 1),
+            (2, 2, 1),
+            (4, 2, 2),
+            (5, 2, 3),
+        ]
+    )
+    def test_nb_batches(self, n_rows, batch_size, expected_nb_batches):
+        df = mock_table_data(rows=n_rows)
+        generator = PandasBatchGenerator(
+            df=df, batch_size=batch_size
+        )
+        assert len(generator) == expected_nb_batches
+
+    @pytest.mark.parametrize(
+        'n_rows, batch_size, expected_last_batch_size',
+        [(4, 2, 2), (5, 2, 1), (7, 3, 1)]
+    )
+    def test_batch_size(self, n_rows, batch_size, expected_last_batch_size):
+        df = mock_table_data(rows=n_rows)
+        generator = PandasBatchGenerator(df=df, batch_size=batch_size)
+        for batch_id in range(len(generator) - 1):
+            batch = generator[batch_id]
+            assert len(batch) == batch_size
+
+        assert len(generator[-1]) == expected_last_batch_size


### PR DESCRIPTION
Allow reading to a generator of df chunks, and writing from such generator to file. Reading currently loads all data in memory - can be re-implemented for formats that support chunking. Writing uses `append`, and is therefore as efficient as each format's implementation.